### PR TITLE
tec: Remove back url on cards with no illustration

### DIFF
--- a/client/src/components/Ly/LyCard.vue
+++ b/client/src/components/Ly/LyCard.vue
@@ -3,7 +3,7 @@
     <header v-if="$slots.header" class="ly-card-header">
       <slot name="header"></slot>
     </header>
-    <div class="ly-card-body" :style="`background-image: url(${image});`">
+    <div class="ly-card-body" :style="style">
       <slot></slot>
     </div>
     <footer v-if="$slots.footer" class="ly-card-footer">
@@ -17,6 +17,17 @@
     props: {
       type: { type: String, default: 'normal' },
       image: { type: String },
+    },
+
+    computed: {
+      style () {
+        if (!this.image) {
+          return {}
+        }
+        return {
+          backgroundImage: `url(${this.image})`,
+        }
+      },
     },
   }
 </script>


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove `background-image` if no `image` attribute is given to card

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [ ] code is properly tested
- [x] tests are passing
- [x] [document API changes](https://github.com/marienfressinaud/lessy/tree/master/docs/api) (optional)
- [x] [document migration notes](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/pull_request.md).
