### PR TITLE
add: #182 Do not list tasks in backlog for non running projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Aquarius XXXX-YY-ZZ
+
+### Breaking changes
+
+- API now exposes `task.startedAt` instead of `task.createdAt`
+
 ## Apus 2017-11-26
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 - API now exposes `task.startedAt` instead of `task.createdAt`
+- API now exposes `task.pausedAt` instead of `task.stoppedAt`
 
 ## Apus 2017-11-26
 

--- a/app/controllers/api/users/tasks_controller.rb
+++ b/app/controllers/api/users/tasks_controller.rb
@@ -17,11 +17,16 @@ private
 
   def create_task_params
     parameters = fetch_resource_params(:task, [:label], [:planned_at, :project_id])
-    parameters[:state] = 'started'
-    parameters[:started_at] = DateTime.now
+    project = Project.find(parameters[:project_id]) if parameters.has_key?(:project_id)
     if parameters.has_key?(:planned_at)
       parameters[:state] = 'planned'
       parameters[:planned_at] = parameters[:planned_at].to_datetime
+      parameters[:started_at] = DateTime.now
+    elsif project.nil? || project.started?
+      parameters[:state] = 'started'
+      parameters[:started_at] = DateTime.now
+    else
+      parameters[:state] = 'newed'
     end
     parameters
   end

--- a/app/models/concerns/project_lifecycle.rb
+++ b/app/models/concerns/project_lifecycle.rb
@@ -25,17 +25,20 @@ module ProjectLifecycle
 
     def on_start(params)
       check_transition_no_limit_started_projects
+      self.tasks.newed.update_all state: 'started', started_at: DateTime.now
       params[:started_at] = DateTime.now
       params
     end
 
     def on_pause(params)
       params[:paused_at] = DateTime.now
+      self.tasks.started.update_all state: 'newed', started_at: nil
       params
     end
 
     def on_restart(params)
       check_transition_no_limit_started_projects
+      self.tasks.newed.update_all state: 'started', started_at: DateTime.now
       params[:paused_at] = nil
       params
     end

--- a/app/models/concerns/task_lifecycle.rb
+++ b/app/models/concerns/task_lifecycle.rb
@@ -19,7 +19,7 @@ module TaskLifecycle
 
       # main workflow
       transition :start, from: :newed, to: :started
-      transition :plan, from: :started, to: :planned
+      transition :plan, from: [:newed, :started], to: :planned
       transition :replan, from: :planned, to: :planned
       transition :finish, from: :planned, to: :finished
 
@@ -40,6 +40,7 @@ module TaskLifecycle
 
     def on_plan(params)
       params[:planned_at] = DateTime.now
+      params[:started_at] = DateTime.now if self.started_at.nil?
       params[:planned_count] = self.planned_count + 1
       params
     end

--- a/app/views/api/projects/_project.jbuilder
+++ b/app/views/api/projects/_project.jbuilder
@@ -4,7 +4,7 @@ json.attributes do
   json.extract! project, :name, :description, :state
   json.started_at project.started_at.to_i
   json.due_at project.due_at.to_i
-  json.stopped_at project.paused_at.to_i
+  json.paused_at project.paused_at.to_i
   json.finished_at project.finished_at.to_i
   json.is_in_progress project.started?
 end

--- a/app/views/api/tasks/_task.jbuilder
+++ b/app/views/api/tasks/_task.jbuilder
@@ -2,7 +2,7 @@ json.type 'task'
 json.id task.id
 json.attributes do
   json.extract! task, :label, :order, :planned_count, :state
-  json.created_at task.started_at.to_i
+  json.started_at task.started_at.to_i
   json.planned_at task.planned_at.to_i
   json.finished_at task.finished_at.to_i
   json.abandoned_at task.abandoned_at.to_i

--- a/client/src/api/projects.js
+++ b/client/src/api/projects.js
@@ -31,7 +31,7 @@ export default {
     })
   },
 
-  stop (project) {
+  pause (project) {
     return put(`/api/projects/${project.id}/state`, {
       project: {
         state: 'paused',

--- a/client/src/components/projects/ProjectFinishForm.vue
+++ b/client/src/components/projects/ProjectFinishForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <ly-form @submit="stop" :error="getErrors()">
+  <ly-form @submit="finish" :error="getErrors()">
     <ly-form-group>
       <ly-form-input
         type="date"
@@ -43,7 +43,7 @@
     },
 
     methods: {
-      stop () {
+      finish () {
         this.$store
           .dispatch('projects/finish', {
             project: this.project,

--- a/client/src/components/projects/ProjectTimeline.vue
+++ b/client/src/components/projects/ProjectTimeline.vue
@@ -13,7 +13,7 @@
         {{ $t('projects.timeline.notStarted') }}
       </span>
       <span v-else-if="project.state === 'paused'" class="project-timeline-labels-diff">
-        {{ $t('projects.timeline.pausedOn', { date: project.stoppedAtLabel }) }}
+        {{ $t('projects.timeline.pausedOn', { date: project.pausedAtLabel }) }}
       </span>
       <span v-else-if="project.state === 'finished'" class="project-timeline-labels-diff">
         {{ $t('projects.timeline.finishedOn', { date: project.finishedAtLabel }) }}
@@ -138,7 +138,7 @@
       },
 
       rawProgression () {
-        const { state, dueAt, stoppedAt, finishedAt, startedAt } = this.project
+        const { state, dueAt, pausedAt, finishedAt, startedAt } = this.project
         if (state === 'newed') {
           return 100
         }
@@ -147,7 +147,7 @@
         const startedDate = moment.unix(startedAt).startOf('day')
         let referenceDate = moment().startOf('day')
         if (state === 'paused') {
-          referenceDate = moment.unix(stoppedAt).startOf('day')
+          referenceDate = moment.unix(pausedAt).startOf('day')
         }
         if (state === 'finished') {
           referenceDate = moment.unix(finishedAt).startOf('day')
@@ -191,9 +191,7 @@
       },
 
       pauseProject () {
-        if (window.confirm(this.$t('projects.timeline.confirmPause'))) {
-          this.$store.dispatch('projects/stop', { project: this.project })
-        }
+        this.$store.dispatch('projects/pause', { project: this.project })
       },
 
       restartProject () {

--- a/client/src/components/projects/ProjectsInboxPage.vue
+++ b/client/src/components/projects/ProjectsInboxPage.vue
@@ -25,8 +25,8 @@
                 {{ project.name }}
               </router-link>
             </ly-list-item-adapt>
-            <ly-badge v-if="project.isStopped" size="small">
-              {{ $t('projects.inboxPage.pausedOn', { date: project.stoppedAtLabel }) }}
+            <ly-badge v-if="project.isPaused" size="small">
+              {{ $t('projects.inboxPage.pausedOn', { date: project.pausedAtLabel }) }}
             </ly-badge>
           </ly-list-item>
         </ly-list-group>

--- a/client/src/components/projects/ProjectsInboxPage.vue
+++ b/client/src/components/projects/ProjectsInboxPage.vue
@@ -28,6 +28,12 @@
             <ly-badge v-if="project.isPaused" size="small">
               {{ $t('projects.inboxPage.pausedOn', { date: project.pausedAtLabel }) }}
             </ly-badge>
+            <ly-badge v-if="project.tasksCount > 0" size="small">
+              {{ $tc('projects.inboxPage.tasksCount', project.tasksCount, {
+                finishedCount: project.finishedTasksCount,
+                totalCount: project.tasksCount,
+              }) }}
+            </ly-badge>
           </ly-list-item>
         </ly-list-group>
       </ly-list>
@@ -43,6 +49,12 @@
             </ly-list-item-adapt>
             <ly-badge size="small">
               {{ $t('projects.inboxPage.finishedLabel', { date: project.finishedAtLabel }) }}
+            </ly-badge>
+            <ly-badge v-if="project.tasksCount > 0" size="small">
+              {{ $tc('projects.inboxPage.tasksCount', project.tasksCount, {
+                finishedCount: project.finishedTasksCount,
+                totalCount: project.tasksCount,
+              }) }}
             </ly-badge>
         </ly-list-item>
       </ly-list>

--- a/client/src/components/tasks/TaskItem.vue
+++ b/client/src/components/tasks/TaskItem.vue
@@ -18,14 +18,14 @@
 
     <ly-badge
       name="indicators"
-      v-if="task.createdSinceWeeks > 0 || task.restartedCount > 0"
-      :type="{ alert: task.createdSinceWeeks > 2 || task.restartedCount > 2, warning: task.createdSinceWeeks === 2 || task.restartedCount === 2 }"
+      v-if="task.startedSinceWeeks > 0 || task.restartedCount > 0"
+      :type="{ alert: task.startedSinceWeeks > 2 || task.restartedCount > 2, warning: task.startedSinceWeeks === 2 || task.restartedCount === 2 }"
     >
       <span
-        v-if="task.createdSinceWeeks > 0"
-        v-tooltip.top="$tc('tasks.item.createdSinceWeeks', task.createdSinceWeeks, { count: task.createdSinceWeeks })"
+        v-if="task.startedSinceWeeks > 0"
+        v-tooltip.top="$tc('tasks.item.startedSinceWeeks', task.startedSinceWeeks, { count: task.startedSinceWeeks })"
       >
-        <ly-icon name="calendar"></ly-icon> {{ task.createdSinceWeeks }}w
+        <ly-icon name="calendar"></ly-icon> {{ task.startedSinceWeeks }}w
       </span>
       <span
         v-if="task.restartedCount > 0"

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -199,6 +199,7 @@ export default {
       projectsPlaceholder: "You don't have any project yet, what are you working on?",
       seeFinishedProjects: 'See your finished project | See your {count} finished projects',
       pausedOn: 'paused on {date}',
+      tasksCount: '{finishedCount} / {totalCount} task | {finishedCount} / {totalCount} tasks',
     },
 
     layout: {

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -223,7 +223,6 @@ export default {
     },
 
     timeline: {
-      confirmPause: 'The project will be marked as paused. Can you confirm?',
       diff: '{days} day | {days} days',
       dueOn: 'Due on {date}',
       dueToday: 'due today',

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -256,7 +256,7 @@ export default {
     item: {
       abandon: 'Abandon',
       confirmAbandon: 'Oh? The task will be marked as abandoned and will disappear from the list. Can you confirm?',
-      createdSinceWeeks: 'You’ve created this task 1 week ago | You’ve created this task {count} weeks ago, it may be time to abandon it, don’t you think?',
+      startedSinceWeeks: 'You’ve started this task 1 week ago | You’ve started this task {count} weeks ago, it may be time to abandon it, don’t you think?',
       dueOn: 'due on {date}',
       edit: 'Edit',
       markAsDone: 'Mark as done',

--- a/client/src/store/modules/projects.js
+++ b/client/src/store/modules/projects.js
@@ -20,18 +20,18 @@ const getters = {
       const params = {
         projectName: project.name,
       }
-      const isStopped = !!project.stoppedAt
+      const isPaused = !!project.pausedAt
       const isFinished = !!project.finishedAt
-      const isStarted = !!project.startedAt && !isStopped
+      const isStarted = !!project.startedAt && !isPaused
       return {
         ...project,
         isStarted,
-        isStopped,
+        isPaused,
         isFinished,
         mdDescription: marked(project.description, { sanitize: true, breaks: true, smartypants: true }),
         startedAtLabel: isStarted ? formatDate(project.startedAt) : '',
         dueAtLabel: isStarted ? formatDate(project.dueAt) : '',
-        stoppedAtLabel: isStopped ? formatDate(project.stoppedAt) : '',
+        pausedAtLabel: isPaused ? formatDate(project.pausedAt) : '',
         finishedAtLabel: isFinished ? formatDate(project.finishedAt) : '',
         finishedTasksCount,
         tasksCount: tasks.length,
@@ -128,9 +128,9 @@ const actions = {
       .then((res) => commit('tasks/startTasksForProject', project.id, { root: true }))
   },
 
-  stop ({ commit }, { project }) {
+  pause ({ commit }, { project }) {
     return projectsApi
-      .stop(project)
+      .pause(project)
       .then((res) => commit('set', res.data))
       .then((res) => commit('tasks/cancelTasksForProject', project.id, { root: true }))
   },

--- a/client/src/store/modules/projects.js
+++ b/client/src/store/modules/projects.js
@@ -122,13 +122,17 @@ const actions = {
   },
 
   start ({ commit }, { project, dueAt }) {
-    return projectsApi.start(project, dueAt)
-                      .then((res) => commit('set', res.data))
+    return projectsApi
+      .start(project, dueAt)
+      .then((res) => commit('set', res.data))
+      .then((res) => commit('tasks/startTasksForProject', project.id, { root: true }))
   },
 
   stop ({ commit }, { project }) {
-    return projectsApi.stop(project)
-                      .then((res) => commit('set', res.data))
+    return projectsApi
+      .stop(project)
+      .then((res) => commit('set', res.data))
+      .then((res) => commit('tasks/cancelTasksForProject', project.id, { root: true }))
   },
 
   finish ({ commit, state }, { project, finishedAt }) {

--- a/client/src/store/modules/projects.js
+++ b/client/src/store/modules/projects.js
@@ -134,10 +134,7 @@ const actions = {
   finish ({ commit, state }, { project, finishedAt }) {
     return projectsApi
       .finish(project, finishedAt)
-      .then((res) => {
-        commit('set', res.data)
-        commit('setNumberFinished', state.numberFinished + 1)
-      })
+      .then((res) => commit('set', res.data))
   },
 }
 

--- a/client/src/store/modules/tasks.js
+++ b/client/src/store/modules/tasks.js
@@ -28,7 +28,7 @@ const getters = {
 
       const isForToday = !isAbandoned && plannedAtDate.isBetween(today.startOf('day'), today.endOf('day'), 'day', '[]')
       const isBacklogged = !isFinished && !isAbandoned && !isForToday
-      const createdSinceWeeks = moment.utc().diff(moment.unix(task.createdAt), 'weeks')
+      const createdSinceWeeks = task.createdAt > 0 ? moment.utc().diff(moment.unix(task.createdAt), 'weeks') : 0
 
       const allowedTags = ['b', 'i', 'em', 'strong']
       const anchorOptions = {

--- a/client/src/store/modules/tasks.js
+++ b/client/src/store/modules/tasks.js
@@ -220,6 +220,34 @@ const mutations = {
     }
   },
 
+  startTasksForProject (state, projectId) {
+    const tasks = Object.entries(state.byIds).map(([id, task]) => {
+      if (task.projectId !== projectId || task.state !== 'newed') {
+        return task
+      }
+      return {
+        ...task,
+        state: 'started',
+        startedAt: +moment(),
+      }
+    })
+    state.byIds = mapElementsById(tasks)
+  },
+
+  cancelTasksForProject (state, projectId) {
+    const tasks = Object.entries(state.byIds).map(([id, task]) => {
+      if (task.projectId !== projectId || task.state !== 'started') {
+        return task
+      }
+      return {
+        ...task,
+        state: 'newed',
+        startedAt: null,
+      }
+    })
+    state.byIds = mapElementsById(tasks)
+  },
+
   reset (state) {
     state.current = null
     state.byIds = {}

--- a/client/src/store/modules/tasks.js
+++ b/client/src/store/modules/tasks.js
@@ -70,7 +70,7 @@ const getters = {
   listBacklog (state, getters) {
     return getters
       .list
-      .filter((task) => task.isBacklogged)
+      .filter((task) => task.isBacklogged && task.state !== 'newed')
   },
 
   listFinished (state, getters) {

--- a/client/src/store/modules/tasks.js
+++ b/client/src/store/modules/tasks.js
@@ -28,7 +28,7 @@ const getters = {
 
       const isForToday = !isAbandoned && plannedAtDate.isBetween(today.startOf('day'), today.endOf('day'), 'day', '[]')
       const isBacklogged = !isFinished && !isAbandoned && !isForToday
-      const createdSinceWeeks = task.createdAt > 0 ? moment.utc().diff(moment.unix(task.createdAt), 'weeks') : 0
+      const startedSinceWeeks = task.startedAt > 0 ? moment.utc().diff(moment.unix(task.startedAt), 'weeks') : 0
 
       const allowedTags = ['b', 'i', 'em', 'strong']
       const anchorOptions = {
@@ -45,7 +45,7 @@ const getters = {
         isBacklogged,
         isFinished,
         isAbandoned,
-        createdSinceWeeks,
+        startedSinceWeeks,
         restartedCount: task.plannedCount - 1,
         plannedAtLabel: formatDate(task.plannedAt),
         formattedLabel: anchorme(sanitizeHtml(task.label, { allowedTags }), anchorOptions),
@@ -104,8 +104,8 @@ const getters = {
   countCreatedByDays (state, getters) {
     const byDays = {}
     getters.list.forEach((task) => {
-      const createdAt = moment.unix(task.createdAt)
-      const key = createdAt.format('YYYY-MM-DD')
+      const startedAt = moment.unix(task.startedAt)
+      const key = startedAt.format('YYYY-MM-DD')
       byDays[key] = (byDays[key] || 0) + 1
     })
     return byDays

--- a/db/migrate/20171224225137_update_task_state_on_not_started_projects.rb
+++ b/db/migrate/20171224225137_update_task_state_on_not_started_projects.rb
@@ -1,0 +1,11 @@
+class UpdateTaskStateOnNotStartedProjects < ActiveRecord::Migration[5.1]
+  def up
+    Project.not_started.find_each do |project|
+      project.tasks.started.update_all state: 'newed', started_at: nil
+    end
+  end
+
+  def down
+    Task.newed.update_all "state = 'started', started_at = created_at"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171007004320) do
+ActiveRecord::Schema.define(version: 20171224225137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -27,7 +27,7 @@ Result format:
 | data.attributes.state                | string | Project's state                          |          |
 | data.attributes.startedAt            | number | Date when project started                |          |
 | data.attributes.dueAt                | number | Date when project should finished        |          |
-| data.attributes.stoppedAt            | number | Date when project has been stopped       |          |
+| data.attributes.pausedAt             | number | Date when project has been paused        |          |
 | data.attributes.finishedAt           | number | Date when project finished               |          |
 | data.attributes.isInProgress         | bool   | `true` if project is started             |          |
 | data.relationships                   | object |                                          |          |
@@ -71,7 +71,7 @@ $ curl -H "Content-Type: application/json" \
       "state": "newed",
       "startedAt": 0,
       "dueAt": 0,
-      "stoppedAt": 0,
+      "pausedAt": 0,
       "finishedAt": 0,
       "isInProgress": false
     },
@@ -111,7 +111,7 @@ Result format:
 | data[].attributes.state                | string | Project's state                          |          |
 | data[].attributes.startedAt            | number | Date when project started                |          |
 | data[].attributes.dueAt                | number | Date when project should finished        |          |
-| data[].attributes.stoppedAt            | number | Date when project has been stopped       |          |
+| data[].attributes.pausedAt             | number | Date when project has been paused        |          |
 | data[].attributes.finishedAt           | number | Date when project finished               |          |
 | data[].attributes.isInProgress         | bool   | `true` if project is started             |          |
 | data[].relationships                   | object |                                          |          |
@@ -151,7 +151,7 @@ $ curl -H "Authorization: <token>" https://lessy.io/api/users/me/projects
         "state": "started",
         "startedAt": 639532800,
         "dueAt": 1504396800,
-        "stoppedAt": 0,
+        "pausedAt": 0,
         "finishedAt": 0,
         "isInProgress": true
       },
@@ -176,7 +176,7 @@ $ curl -H "Authorization: <token>" https://lessy.io/api/users/me/projects
         "state": "newed",
         "startedAt": 0,
         "dueAt": 0,
-        "stoppedAt": 0,
+        "pausedAt": 0,
         "finishedAt": 0,
         "isInProgress": false
       },
@@ -227,7 +227,7 @@ Result format:
 | data.attributes.state                | string | Project's state                          |          |
 | data.attributes.startedAt            | number | Date when project started                |          |
 | data.attributes.dueAt                | number | Date when project should finished        |          |
-| data.attributes.stoppedAt            | number | Date when project has been stopped       |          |
+| data.attributes.pausedAt             | number | Date when project has been paused        |          |
 | data.attributes.finishedAt           | number | Date when project finished               |          |
 | data.attributes.isInProgress         | bool   | `true` if project is started             |          |
 | data.relationships                   | object |                                          |          |
@@ -271,7 +271,7 @@ $ curl -H "Content-Type: application/json" \
       "state": "newed",
       "startedAt": 0,
       "dueAt": 0,
-      "stoppedAt": 0,
+      "pausedAt": 0,
       "finishedAt": 0,
       "isInProgress": false
     },
@@ -344,7 +344,7 @@ Result format:
 | data.attributes.state                | string | Project's state                          |          |
 | data.attributes.startedAt            | number | Date when project started                |          |
 | data.attributes.dueAt                | number | Date when project should finished        |          |
-| data.attributes.stoppedAt            | number | Date when project has been stopped       |          |
+| data.attributes.pausedAt             | number | Date when project has been paused        |          |
 | data.attributes.finishedAt           | number | Date when project finished               |          |
 | data.attributes.isInProgress         | bool   | `true` if project is started             |          |
 | data.relationships                   | object |                                          |          |
@@ -391,7 +391,7 @@ $ curl -H "Content-Type: application/json" \
       "state": "started",
       "startedAt": 1507449826,
       "dueAt": 1545696000,
-      "stoppedAt": 0,
+      "pausedAt": 0,
       "finishedAt": 0,
       "isInProgress": true
     },

--- a/docs/api/tasks.md
+++ b/docs/api/tasks.md
@@ -13,10 +13,14 @@ Parameters:
 | task.planned\_at | number | Task's due date         | yes      |
 | task.project\_id | number | Task's project relation | yes      |
 
-Note: in Lessy, if `planned_at` is set for today, task appears in today list.
-Otherwise (either `nil` or another day), it appears in the backlog. If
-`planned_at` is set, task's `state` is set to `planned` and `planned_count` to
-1, otherwise `state` is set to `started` and `planned_count` to 0.
+Notes:
+
+- if `planned_at` is provided, `state` is always set to `planned` and
+  `planned_count` to 1
+- otherwise, if `project_id` matches with a not started project, `state` is set
+  to `newed`
+- in other situations (project is started or no `project_id` is provided),
+  task's state is set to `started`
 
 Result format:
 
@@ -309,8 +313,9 @@ Parameters:
 | task.state       | string | Task's state            |          |
 
 Note: possible values of `state` are `newed`, `started`, `planned`, `finished`
-or `abandoned`. A created task's state is `started` or `planned` depending on
-if `planned_at` has been given. Lessy doesn't make use of `newed` state yet.
+or `abandoned`. Please refer to [task creation notes](#post-apiusersmetasks) to
+know more about initial state.
+
 State follow this state's machine:
 
 ```ascii

--- a/docs/api/tasks.md
+++ b/docs/api/tasks.md
@@ -34,7 +34,7 @@ Result format:
 | data.attributes.order                           | number | Task's order                             |          |
 | data.attributes.plannedCount                    | number | Number of times task has been planned    |          |
 | data.attributes.state                           | string | Task's state                             |          |
-| data.attributes.createdAt                       | number | Date when task has been created          |          |
+| data.attributes.startedAt                       | number | Date when task has been created          |          |
 | data.attributes.plannedAt                       | number | Task's due date                          |          |
 | data.attributes.finishedAt                      | number | Date when task has been finished         |          |
 | data.attributes.abandonedAt                     | number | Date when task has been abandoned        |          |
@@ -74,7 +74,7 @@ $ curl -H "Content-Type: application/json" \
       "order": 2,
       "plannedCount": 0,
       "state": "started",
-      "createdAt": 1507454795,
+      "startedAt": 1507454795,
       "plannedAt": 0,
       "finishedAt": 0,
       "abandonedAt": 0
@@ -123,7 +123,7 @@ Result format:
 | data[].attributes.order                           | number | Task's order                             |          |
 | data[].attributes.plannedCount                    | number | Number of times task has been planned    |          |
 | data[].attributes.state                           | string | Task's state                             |          |
-| data[].attributes.createdAt                       | number | Date when task has been created          |          |
+| data[].attributes.startedAt                       | number | Date when task has been created          |          |
 | data[].attributes.plannedAt                       | number | Task's due date                          |          |
 | data[].attributes.finishedAt                      | number | Date when task has been finished         |          |
 | data[].attributes.abandonedAt                     | number | Date when task has been abandoned        |          |
@@ -165,7 +165,7 @@ $ curl -H "Authorization: <token>" https://lessy.io/api/users/me/tasks
         "order": 1,
         "plannedCount": 1,
         "state": "planned",
-        "createdAt": 1484870400,
+        "startedAt": 1484870400,
         "plannedAt": 1507455286,
         "finishedAt": 0,
         "abandonedAt": 0
@@ -187,7 +187,7 @@ $ curl -H "Authorization: <token>" https://lessy.io/api/users/me/tasks
         "order": 2,
         "plannedCount": 0,
         "state": "started",
-        "createdAt": 1507454795,
+        "startedAt": 1507454795,
         "plannedAt": 0,
         "finishedAt": 0,
         "abandonedAt": 0
@@ -238,7 +238,7 @@ Result format:
 | data.attributes.order                           | number | Task's order                             |          |
 | data.attributes.plannedCount                    | number | Number of times task has been planned    |          |
 | data.attributes.state                           | string | Task's state                             |          |
-| data.attributes.createdAt                       | number | Date when task has been created          |          |
+| data.attributes.startedAt                       | number | Date when task has been created          |          |
 | data.attributes.plannedAt                       | number | Task's due date                          |          |
 | data.attributes.finishedAt                      | number | Date when task has been finished         |          |
 | data.attributes.abandonedAt                     | number | Date when task has been abandoned        |          |
@@ -278,7 +278,7 @@ $ curl -H "Content-Type: application/json" \
       "order": 2,
       "plannedCount": 0,
       "state": "started",
-      "createdAt": 1507454795,
+      "startedAt": 1507454795,
       "plannedAt": 0,
       "finishedAt": 0,
       "abandonedAt": 0
@@ -359,7 +359,7 @@ Result format:
 | data.attributes.order                           | number | Task's order                             |          |
 | data.attributes.plannedCount                    | number | Number of times task has been planned    |          |
 | data.attributes.state                           | string | Task's state                             |          |
-| data.attributes.createdAt                       | number | Date when task has been created          |          |
+| data.attributes.startedAt                       | number | Date when task has been created          |          |
 | data.attributes.plannedAt                       | number | Task's due date                          |          |
 | data.attributes.finishedAt                      | number | Date when task has been finished         |          |
 | data.attributes.abandonedAt                     | number | Date when task has been abandoned        |          |
@@ -405,7 +405,7 @@ $ curl -H "Content-Type: application/json" \
       "order": 2,
       "plannedCount": 1,
       "state": "planned",
-      "createdAt": 1507454795,
+      "startedAt": 1507454795,
       "plannedAt": 1507457002,
       "finishedAt": 0,
       "abandonedAt": 0

--- a/docs/api/tasks.md
+++ b/docs/api/tasks.md
@@ -320,10 +320,10 @@ State follow this state's machine:
 
 ```ascii
 +------------------------------------------------------------------------------+
-|                                                          replan              |
-|                                                         +-----+              |
-|                                                         |     |              |
-|  +------------+    start    +------------+   plan    +--+-----v---+          |
+|                                              plan          replan            |
+|           +--------------------------------------------+  +-----+            |
+|           |                                            |  |     |            |
+|  +--------+---+    start    +------------+   plan    +-v--+-----v-+          |
 |  | newed      +-------------> started    +-----------> planned    +-+        |
 |  +--------^---+             +-----+------+           +----+----^--+ |        |
 |           |                       |                       |    |    |        |
@@ -340,7 +340,7 @@ State follow this state's machine:
 
 Also, following rules apply:
 
-- `started_at` is set to now on `start` action
+- `started_at` is set to now on `start` and `plan` actions if not already set
 - `planned_at` is set to now and `planned_count` is incremented by one on
   `plan` and `replan` actions
 - `finished_at` is set to nil on `replan` and to now on `finish`

--- a/docs/backend/endpoints_design.md
+++ b/docs/backend/endpoints_design.md
@@ -64,7 +64,7 @@ have `attributes` and `relationships`:
       "description": "",
       "startedAt": 0,
       "dueAt": 0,
-      "stoppedAt": 0,
+      "pausedAt": 0,
       "finishedAt": 0,
       "isInProgress": false
     },

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -225,6 +225,29 @@ RSpec.describe Task, type: :model do
       end
     end
 
+    context 'when planning a newed task' do
+      let(:task) { create :task, :newed, planned_count: 0 }
+      let(:params) { {
+        state: 'planned',
+      } }
+
+      it 'sets task state to planned' do
+        expect(subject.reload.state).to eq('planned')
+      end
+
+      it 'sets planned_at attribute to today' do
+        expect(subject.reload.planned_at).to eq(DateTime.new(2017, 1, 20))
+      end
+
+      it 'sets started_at attribute to today' do
+        expect(subject.reload.started_at).to eq(DateTime.new(2017, 1, 20))
+      end
+
+      it 'increments planned_count by 1' do
+        expect(subject.reload.planned_count).to eq(1)
+      end
+    end
+
     context 'when planning a started task' do
       let(:task) { create :task, :started, planned_count: 0 }
       let(:params) { {
@@ -283,18 +306,6 @@ RSpec.describe Task, type: :model do
 
       it 'increments planned_count by 1' do
         expect(subject.reload.planned_count).to eq(2)
-      end
-    end
-
-    context 'when trying to plan a newed task' do
-      let(:task) { create :task, :newed }
-      let(:params) { {
-        state: 'planned',
-      } }
-
-      it 'fails' do
-        expect { subject }
-          .to raise_error(Task::InvalidTransition, /Task cannot transition from 'newed' to 'planned'/)
       end
     end
 

--- a/spec/requests/api/projects_request_spec.rb
+++ b/spec/requests/api/projects_request_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe Api::ProjectsController, type: :request do
 
     context 'when starting a project' do
       let(:project) { create :project, :newed, user: user }
+      let!(:task) { create :task, :newed, project: project }
       let(:payload) { {
         project: {
           state: 'started',
@@ -192,6 +193,11 @@ RSpec.describe Api::ProjectsController, type: :request do
         it 'sets started_at to now' do
           expect(project.reload.started_at).to eq(DateTime.new(2017, 1, 20))
         end
+
+        it 'starts newed task' do
+          expect(task.reload.state).to eq('started')
+          expect(task.reload.started_at).to eq(DateTime.now)
+        end
       end
 
       context 'with a paused project' do
@@ -205,6 +211,11 @@ RSpec.describe Api::ProjectsController, type: :request do
 
         it 'sets paused_at to nil' do
           expect(project.reload.paused_at).to be_nil
+        end
+
+        it 'starts newed task' do
+          expect(task.reload.state).to eq('started')
+          expect(task.reload.started_at).to eq(DateTime.now)
         end
       end
 
@@ -335,8 +346,9 @@ RSpec.describe Api::ProjectsController, type: :request do
       end
     end
 
-    context 'when stopping a project' do
+    context 'when pausing a project' do
       let(:project) { create :project, :started, user: user, started_at: DateTime.new(2017, 1, 1) }
+      let!(:task) { create :task, :started, project: project }
       let(:payload) { {
         project: {
           state: 'paused',
@@ -356,6 +368,11 @@ RSpec.describe Api::ProjectsController, type: :request do
 
         it 'saves paused_at' do
           expect(project.reload.paused_at).to eq(DateTime.new(2017, 1, 20))
+        end
+
+        it 'cancels started task' do
+          expect(task.reload.state).to eq('newed')
+          expect(task.reload.started_at).to be nil
         end
       end
     end

--- a/spec/requests/api/users/tasks_request_spec.rb
+++ b/spec/requests/api/users/tasks_request_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Api::Users::TasksController, type: :request do
         expect(task['id']).not_to be_nil
         expect(task['attributes']['label']).to eq('My task')
         expect(task['attributes']['state']).to eq('started')
-        expect(task['attributes']['createdAt']).to eq(DateTime.now.to_i)
+        expect(task['attributes']['startedAt']).to eq(DateTime.now.to_i)
       end
     end
 
@@ -142,7 +142,7 @@ RSpec.describe Api::Users::TasksController, type: :request do
         expect(task['id']).not_to be_nil
         expect(task['attributes']['label']).to eq('My task')
         expect(task['attributes']['state']).to eq('planned')
-        expect(task['attributes']['createdAt']).to eq(DateTime.now.to_i)
+        expect(task['attributes']['startedAt']).to eq(DateTime.now.to_i)
         expect(task['attributes']['plannedAt']).to eq(DateTime.new(2017).to_i)
       end
     end
@@ -191,7 +191,7 @@ RSpec.describe Api::Users::TasksController, type: :request do
         expect(task['id']).not_to be_nil
         expect(task['attributes']['label']).to eq('My task')
         expect(task['attributes']['state']).to eq('started')
-        expect(task['attributes']['createdAt']).to eq(DateTime.now.to_i)
+        expect(task['attributes']['startedAt']).to eq(DateTime.now.to_i)
         expect(task['relationships']['project']['data']['id']).to eq(project.id)
       end
     end

--- a/spec/requests/api/users/tasks_request_spec.rb
+++ b/spec/requests/api/users/tasks_request_spec.rb
@@ -91,7 +91,6 @@ RSpec.describe Api::Users::TasksController, type: :request do
     let(:payload) { {
       task: {
         label: 'My task',
-        planned_at: DateTime.new(2017).to_i,
       },
     } }
     let(:token) { user.token }
@@ -100,7 +99,7 @@ RSpec.describe Api::Users::TasksController, type: :request do
                                             headers: { 'Authorization': token },
                                             as: :json }
 
-    context 'with valid attributes' do
+    context 'with minimum attributes' do
       before { subject }
 
       it 'succeeds' do
@@ -119,16 +118,40 @@ RSpec.describe Api::Users::TasksController, type: :request do
         task = JSON.parse(response.body)['data']
         expect(task['id']).not_to be_nil
         expect(task['attributes']['label']).to eq('My task')
-        expect(task['attributes']['plannedAt']).to eq(DateTime.new(2017).to_i)
+        expect(task['attributes']['state']).to eq('started')
+        expect(task['attributes']['createdAt']).to eq(DateTime.now.to_i)
       end
     end
 
-    context 'with project_id' do
-      let(:project) { create :project }
+    context 'with planned date' do
       let(:payload) { {
         task: {
           label: 'My task',
           planned_at: DateTime.new(2017).to_i,
+        },
+      } }
+
+      before { subject }
+
+      it 'succeeds' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'returns the new task' do
+        task = JSON.parse(response.body)['data']
+        expect(task['id']).not_to be_nil
+        expect(task['attributes']['label']).to eq('My task')
+        expect(task['attributes']['state']).to eq('planned')
+        expect(task['attributes']['createdAt']).to eq(DateTime.now.to_i)
+        expect(task['attributes']['plannedAt']).to eq(DateTime.new(2017).to_i)
+      end
+    end
+
+    context 'with not started project' do
+      let(:project) { create :project, :newed }
+      let(:payload) { {
+        task: {
+          label: 'My task',
           project_id: project.id,
         },
       } }
@@ -143,15 +166,17 @@ RSpec.describe Api::Users::TasksController, type: :request do
         task = JSON.parse(response.body)['data']
         expect(task['id']).not_to be_nil
         expect(task['attributes']['label']).to eq('My task')
-        expect(task['attributes']['plannedAt']).to eq(DateTime.new(2017).to_i)
+        expect(task['attributes']['state']).to eq('newed')
         expect(task['relationships']['project']['data']['id']).to eq(project.id)
       end
     end
 
-    context 'with no planned date' do
+    context 'with started project' do
+      let(:project) { create :project, :started }
       let(:payload) { {
         task: {
           label: 'My task',
+          project_id: project.id,
         },
       } }
 
@@ -165,7 +190,9 @@ RSpec.describe Api::Users::TasksController, type: :request do
         task = JSON.parse(response.body)['data']
         expect(task['id']).not_to be_nil
         expect(task['attributes']['label']).to eq('My task')
-        expect(task['attributes']['plannedAt']).to eq(0)
+        expect(task['attributes']['state']).to eq('started')
+        expect(task['attributes']['createdAt']).to eq(DateTime.now.to_i)
+        expect(task['relationships']['project']['data']['id']).to eq(project.id)
       end
     end
 

--- a/spec/support/api/schemas/projects/project.json
+++ b/spec/support/api/schemas/projects/project.json
@@ -6,7 +6,7 @@
     "id": { "type": "integer" },
     "attributes": {
       "type": "object",
-      "required": ["name", "description", "startedAt", "dueAt", "stoppedAt",
+      "required": ["name", "description", "startedAt", "dueAt", "pausedAt",
                    "finishedAt", "isInProgress", "state"],
       "properties": {
         "name": { "type": "string" },
@@ -14,7 +14,7 @@
         "state": { "type": "string" },
         "startedAt": { "type": "integer" },
         "dueAt": { "type": "integer" },
-        "stoppedAt": { "type": "integer" },
+        "pausedAt": { "type": "integer" },
         "finishedAt": { "type": "integer" },
         "isInProgress": { "type": "boolean" }
       },

--- a/spec/support/api/schemas/tasks/task.json
+++ b/spec/support/api/schemas/tasks/task.json
@@ -6,14 +6,14 @@
     "id": { "type": "integer" },
     "attributes": {
       "type": "object",
-      "required": ["label", "order", "plannedCount", "createdAt", "plannedAt",
+      "required": ["label", "order", "plannedCount", "startedAt", "plannedAt",
                    "finishedAt", "abandonedAt", "state"],
       "properties": {
         "label": { "type": "string" },
         "order": { "type": "integer" },
         "plannedCount": { "type": "integer" },
         "state": { "type": "string" },
-        "createdAt": { "type": "integer" },
+        "startedAt": { "type": "integer" },
         "plannedAt": { "type": "integer" },
         "finishedAt": { "type": "integer" },
         "abandonedAt": { "type": "integer" }


### PR DESCRIPTION
Closes #182 

Changes proposed in this pull request:

- make tasks "newed" when created on non-started projects
- make newed tasks "started" when  (re)starting a project
- do not list "newed" tasks in backlog
- show number of tasks attached to projects in inbox

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] [document API changes](https://github.com/marienfressinaud/lessy/tree/master/docs/api) (optional)
- [x] [document migration notes](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/pull_request.md).
