### PR TITLE
imp: #168 Relax requirements for project names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Aquarius XXXX-YY-ZZ
 
-### Breaking changes
+### API changes
 
-- API now exposes `task.startedAt` instead of `task.createdAt`
-- API now exposes `task.pausedAt` instead of `task.stoppedAt`
+- `task.createdAt` becomes `task.startedAt`
+- `project.stoppedAt` becomes `project.pausedAt`
+- `project.slug` is added
 
 ## Apus 2017-11-26
 

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -21,7 +21,6 @@ private
     permitted_params << :due_at if current_project.started?
     update_params = params.require(:project).permit(*permitted_params)
     update_params[:due_at] = update_params[:due_at].to_datetime if update_params.has_key? :due_at
-    update_params[:slug] = update_params[:name]
     update_params
   end
 

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -21,6 +21,7 @@ private
     permitted_params << :due_at if current_project.started?
     update_params = params.require(:project).permit(*permitted_params)
     update_params[:due_at] = update_params[:due_at].to_datetime if update_params.has_key? :due_at
+    update_params[:slug] = update_params[:name]
     update_params
   end
 

--- a/app/controllers/api/users/projects_controller.rb
+++ b/app/controllers/api/users/projects_controller.rb
@@ -12,9 +12,7 @@ class Api::Users::ProjectsController < ApiController
 private
 
   def create_project_params
-    parameters = fetch_resource_params(:project, [:name]).merge(user: current_user)
-    parameters[:slug] = parameters[:name]
-    parameters
+    fetch_resource_params(:project, [:name]).merge(user: current_user)
   end
 
 end

--- a/app/controllers/api/users/projects_controller.rb
+++ b/app/controllers/api/users/projects_controller.rb
@@ -12,7 +12,9 @@ class Api::Users::ProjectsController < ApiController
 private
 
   def create_project_params
-    fetch_resource_params(:project, [:name]).merge(user: current_user)
+    parameters = fetch_resource_params(:project, [:name]).merge(user: current_user)
+    parameters[:slug] = parameters[:name]
+    parameters
   end
 
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,7 +4,7 @@ class Project < ApplicationRecord
   belongs_to :user
   has_many :tasks, dependent: :nullify
 
-  validates :user, :name, presence: true
+  validates :user, :name, :slug, presence: true
   validates :name, uniqueness: { scope: :user, message: 'must be unique per user' },
                    format: { with: /\A[\w\-]{1,}\z/, message: 'must contain letters, numbers, underscores (_) and hiphens (-) only' },
                    length: { maximum: 100 }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,10 +5,13 @@ class Project < ApplicationRecord
   has_many :tasks, dependent: :nullify
 
   validates :user, :name, :slug, presence: true
-  validates :name, uniqueness: { scope: :user, message: 'must be unique per user' },
-                   format: { with: /\A[\w\-]{1,}\z/, message: 'must contain letters, numbers, underscores (_) and hiphens (-) only' },
-                   length: { maximum: 100 }
+  validates :slug, uniqueness: { scope: :user, message: 'must be unique per user' },
+                   format: { with: /\A[\w\-]{1,}\z/, message: 'must contain letters, numbers, underscores (_) and hiphens (-) only' }
+  validates :name, length: { maximum: 100 }
 
   paginates_per 25
 
+  before_validation do
+    self.slug = self.name.parameterize
+  end
 end

--- a/app/views/api/projects/_project.jbuilder
+++ b/app/views/api/projects/_project.jbuilder
@@ -1,7 +1,7 @@
 json.type 'project'
 json.id project.id
 json.attributes do
-  json.extract! project, :name, :description, :state
+  json.extract! project, :name, :slug, :description, :state
   json.started_at project.started_at.to_i
   json.due_at project.due_at.to_i
   json.paused_at project.paused_at.to_i

--- a/app/views/api/tasks/_task.jbuilder
+++ b/app/views/api/tasks/_task.jbuilder
@@ -23,6 +23,7 @@ json.relationships do
         json.id task.project_id
         json.attributes do
           json.name task.project.name
+          json.slug task.project.slug
         end
       end
     end

--- a/client/src/components/projects/ProjectCreateForm.vue
+++ b/client/src/components/projects/ProjectCreateForm.vue
@@ -6,8 +6,8 @@
         name="name"
         v-model="name"
         ref="nameInput"
-        :error="getErrors('/project/name')"
-        pattern="[\w\-]{1,100}"
+        :error="getErrors('/project/name') || getErrors('/project/slug')"
+        pattern=".{1,100}"
         :caption="$t('projects.createForm.nameCaption')"
         autocomplete="off"
         required

--- a/client/src/components/projects/ProjectLayout.vue
+++ b/client/src/components/projects/ProjectLayout.vue
@@ -13,8 +13,8 @@
     },
 
     mounted () {
-      const { projectName } = this.$route.params
-      this.$store.commit('projects/setCurrent', projectName)
+      const { projectSlug } = this.$route.params
+      this.$store.commit('projects/setCurrent', projectSlug)
     },
 
     destroyed () {

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -48,10 +48,13 @@ export default {
 
       name: {
         blank: 'Name is required.',
-        invalid: 'Name does not match required pattern (only letters, numbers, underscores and hiphens are accepted).',
         parameter_missing: 'Name is required.',
-        taken: 'You already have a project with the same name.',
         too_long: 'Name is too long (max 100 characters).',
+      },
+
+      slug: {
+        invalid: 'Something went wrong when saving the project (does its name contain any special character?). Please choose another name.',
+        taken: 'This name is close to another of your project names, please try to change it.',
       },
 
       state: {
@@ -166,7 +169,7 @@ export default {
     createForm: {
       cancel: 'Cancel',
       submit: 'Create',
-      nameCaption: 'Only letters, numbers, underscores (_) and hiphens (-)',
+      nameCaption: 'Maximum 100 characters.',
     },
 
     editForm: {

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -53,7 +53,7 @@ const routes = [
     children: [
       { path: '', redirect: 'inbox' },
       { path: 'inbox', component: ProjectsInboxPage, meta: { title: 'Inbox' } },
-      { path: ':projectName',
+      { path: ':projectSlug',
         component: ProjectLayout,
         children: [
           { path: '', component: ProjectShowPage, name: 'project/show', meta: { title: 'Project' } },

--- a/client/src/store/modules/projects.js
+++ b/client/src/store/modules/projects.js
@@ -18,7 +18,7 @@ const getters = {
       const tasks = rootGetters['tasks/listForProject'](project)
       const finishedTasksCount = tasks.filter(task => task.isFinished).length
       const params = {
-        projectName: project.name,
+        projectSlug: project.slug,
       }
       const isPaused = !!project.pausedAt
       const isFinished = !!project.finishedAt
@@ -158,9 +158,9 @@ const mutations = {
     }
   },
 
-  setCurrent (state, projectName) {
+  setCurrent (state, projectSlug) {
     state.current = Object.keys(state.byIds)
-                          .find((id) => state.byIds[id].name === projectName)
+                          .find((id) => state.byIds[id].slug === projectSlug)
   },
 
   addTaskToProject (state, { projectId, taskId }) {

--- a/client/src/store/modules/projects.js
+++ b/client/src/store/modules/projects.js
@@ -85,20 +85,6 @@ const getters = {
     }, 0)
     return nbStartedProjects < 3
   },
-
-  numberCurrent (state, getters) {
-    return Object.keys(state.byIds)
-      .map(getters.findById)
-      .filter((project) => !project.isFinished)
-      .length
-  },
-
-  numberFinished (state, getters) {
-    return Object.keys(state.byIds)
-      .map(getters.findById)
-      .filter((project) => project.isFinished)
-      .length
-  },
 }
 
 const actions = {

--- a/client/src/store/modules/tasks.js
+++ b/client/src/store/modules/tasks.js
@@ -49,7 +49,7 @@ const getters = {
         restartedCount: task.plannedCount - 1,
         plannedAtLabel: formatDate(task.plannedAt),
         formattedLabel: anchorme(sanitizeHtml(task.label, { allowedTags }), anchorOptions),
-        urlProjectShow: task.projectName && { name: 'project/show', params: { projectName: task.projectName } },
+        urlProjectShow: task.projectSlug && { name: 'project/show', params: { projectSlug: task.projectSlug } },
       }
     }
   },
@@ -182,6 +182,7 @@ const mutations = {
       if (element.relationships.project.data != null) {
         byIds[element.id].projectId = element.relationships.project.data.id
         byIds[element.id].projectName = element.relationships.project.data.attributes.name
+        byIds[element.id].projectSlug = element.relationships.project.data.attributes.slug
       }
     })
 
@@ -203,6 +204,7 @@ const mutations = {
     if (data.relationships.project.data != null) {
       byIds[data.id].projectId = data.relationships.project.data.id
       byIds[data.id].projectName = data.relationships.project.data.attributes.name
+      byIds[data.id].projectSlug = data.relationships.project.data.attributes.slug
     }
     state.byIds = byIds
   },

--- a/db/migrate/20171226101352_add_slug_to_project.rb
+++ b/db/migrate/20171226101352_add_slug_to_project.rb
@@ -1,0 +1,7 @@
+class AddSlugToProject < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :slug, :string
+    Project.update_all 'slug = name'
+    change_column_null :projects, :slug, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171224225137) do
+ActiveRecord::Schema.define(version: 20171226101352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20171224225137) do
     t.datetime "finished_at"
     t.datetime "paused_at"
     t.string "state", default: "newed", null: false
+    t.string "slug", null: false
     t.index ["name", "user_id"], name: "index_projects_on_name_and_user_id", unique: true
     t.index ["name"], name: "index_projects_on_name"
     t.index ["user_id"], name: "index_projects_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,13 +16,13 @@ user.activate!
 
 puts 'Creating Projects records...'
 Project.create!([
-  { name: Faker::Company.catch_phrase.gsub(/\s/, '-'), user: user },
-  { name: Faker::Company.catch_phrase.gsub(/\s/, '-'), user: user },
-  { name: Faker::Company.catch_phrase.gsub(/\s/, '-'), user: user },
-  { name: Faker::Company.catch_phrase.gsub(/\s/, '-'), user: user },
-  { name: Faker::Company.catch_phrase.gsub(/\s/, '-'), user: user },
-  { name: Faker::Company.catch_phrase.gsub(/\s/, '-'), user: user, state: 'started', started_at: 30.days.ago, due_at: 20.days.from_now },
-  { name: Faker::Company.catch_phrase.gsub(/\s/, '-'), user: user, state: 'started', started_at: 10.days.ago, due_at: 42.days.from_now },
+  { name: Faker::Company.catch_phrase, user: user },
+  { name: Faker::Company.catch_phrase, user: user },
+  { name: Faker::Company.catch_phrase, user: user },
+  { name: Faker::Company.catch_phrase, user: user },
+  { name: Faker::Company.catch_phrase, user: user },
+  { name: Faker::Company.catch_phrase, user: user, state: 'started', started_at: 30.days.ago, due_at: 20.days.from_now },
+  { name: Faker::Company.catch_phrase, user: user, state: 'started', started_at: 10.days.ago, due_at: 42.days.from_now },
 ])
 
 puts 'Creating Tasks records...'

--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -23,6 +23,7 @@ Result format:
 | data.id                              | number | Project's identifier                     |          |
 | data.attributes                      | object |                                          |          |
 | data.attributes.name                 | string | Project's name                           |          |
+| data.attributes.slug                 | string | Project's slug (URL fragment)            |          |
 | data.attributes.description          | string | Project's description                    |          |
 | data.attributes.state                | string | Project's state                          |          |
 | data.attributes.startedAt            | number | Date when project started                |          |
@@ -67,6 +68,7 @@ $ curl -H "Content-Type: application/json" \
     "id": 42,
     "attributes": {
       "name": "damn-good-coffee",
+      "slug": "damn-good-coffee",
       "description": "",
       "state": "newed",
       "startedAt": 0,
@@ -107,6 +109,7 @@ Result format:
 | data[].id                              | number | Project's identifier                     |          |
 | data[].attributes                      | object |                                          |          |
 | data[].attributes.name                 | string | Project's name                           |          |
+| data[].attributes.slug                 | string | Project's slug (URL fragment)            |          |
 | data[].attributes.description          | string | Project's description                    |          |
 | data[].attributes.state                | string | Project's state                          |          |
 | data[].attributes.startedAt            | number | Date when project started                |          |
@@ -147,6 +150,7 @@ $ curl -H "Authorization: <token>" https://lessy.io/api/users/me/projects
       "id": 24,
       "attributes": {
         "name": "black-lodge",
+        "slug": "black-lodge",
         "description": "A mysterious dark place",
         "state": "started",
         "startedAt": 639532800,
@@ -172,6 +176,7 @@ $ curl -H "Authorization: <token>" https://lessy.io/api/users/me/projects
       "id": 42,
       "attributes": {
         "name": "damn-good-coffee",
+        "slug": "damn-good-coffee",
         "description": "",
         "state": "newed",
         "startedAt": 0,
@@ -223,6 +228,7 @@ Result format:
 | data.id                              | number | Project's identifier                     |          |
 | data.attributes                      | object |                                          |          |
 | data.attributes.name                 | string | Project's name                           |          |
+| data.attributes.slug                 | string | Project's slug (URL fragment)            |          |
 | data.attributes.description          | string | Project's description                    |          |
 | data.attributes.state                | string | Project's state                          |          |
 | data.attributes.startedAt            | number | Date when project started                |          |
@@ -267,6 +273,7 @@ $ curl -H "Content-Type: application/json" \
     "id": 42,
     "attributes": {
       "name": "damn-good-coffee",
+      "slug": "damn-good-coffee",
       "description": "Wait a minute! Wait a minute! [...] You know, this is, excuse me, a damn fine cup of coffee.",
       "state": "newed",
       "startedAt": 0,
@@ -340,6 +347,7 @@ Result format:
 | data.id                              | number | Project's identifier                     |          |
 | data.attributes                      | object |                                          |          |
 | data.attributes.name                 | string | Project's name                           |          |
+| data.attributes.slug                 | string | Project's slug (URL fragment)            |          |
 | data.attributes.description          | string | Project's description                    |          |
 | data.attributes.state                | string | Project's state                          |          |
 | data.attributes.startedAt            | number | Date when project started                |          |
@@ -387,6 +395,7 @@ $ curl -H "Content-Type: application/json" \
     "id": 42,
     "attributes": {
       "name": "damn-good-coffee",
+      "slug": "damn-good-coffee",
       "description": "Wait a minute! Wait a minute! [...] You know, this is, excuse me, a damn fine cup of coffee.",
       "state": "started",
       "startedAt": 1507449826,

--- a/docs/api/tasks.md
+++ b/docs/api/tasks.md
@@ -49,6 +49,7 @@ Result format:
 | data.relationships.project.data.id              | number | Project's identifier                     |          |
 | data.relationships.project.data.attributes      | object |                                          |          |
 | data.relationships.project.data.attributes.name | string | Project's name                           |          |
+| data.relationships.project.data.attributes.slug | string | Project's slug (URL fragment)            |          |
 
 **Important note :** this output may evolve quite soon!
 
@@ -88,7 +89,8 @@ $ curl -H "Content-Type: application/json" \
           "type": "project",
           "id": 42,
           "attributes": {
-            "name": "damn-good-coffee"
+            "name": "damn-good-coffee",
+            "slug": "damn-good-coffee"
           }
         }
       }
@@ -138,6 +140,7 @@ Result format:
 | data[].relationships.project.data.id              | number | Project's identifier                     |          |
 | data[].relationships.project.data.attributes      | object |                                          |          |
 | data[].relationships.project.data.attributes.name | string | Project's name                           |          |
+| data[].relationships.project.data.attributes.slug | string | Project's slug (URL fragment)            |          |
 | links                                             | object |                                          |          |
 | links.first                                       | string | Link to the first page of pagination     |          |
 | links.last                                        | string | Link to the last page of pagination      |          |
@@ -201,7 +204,8 @@ $ curl -H "Authorization: <token>" https://lessy.io/api/users/me/tasks
             "type": "project",
             "id": 42,
             "attributes": {
-              "name": "damn-good-coffee"
+              "name": "damn-good-coffee",
+              "slug": "damn-good-coffee"
             }
           }
         }
@@ -253,6 +257,7 @@ Result format:
 | data.relationships.project.data.id              | number | Project's identifier                     |          |
 | data.relationships.project.data.attributes      | object |                                          |          |
 | data.relationships.project.data.attributes.name | string | Project's name                           |          |
+| data.relationships.project.data.attributes.slug | string | Project's slug (URL fragment)            |          |
 
 **Important note :** this output may evolve quite soon!
 
@@ -292,7 +297,8 @@ $ curl -H "Content-Type: application/json" \
           "type": "project",
           "id": 42,
           "attributes": {
-            "name": "damn-good-coffee"
+            "name": "damn-good-coffee",
+            "slug": "damn-good-coffee"
           }
         }
       }
@@ -374,6 +380,7 @@ Result format:
 | data.relationships.project.data.id              | number | Project's identifier                     |          |
 | data.relationships.project.data.attributes      | object |                                          |          |
 | data.relationships.project.data.attributes.name | string | Project's name                           |          |
+| data.relationships.project.data.attributes.slug | string | Project's slug (URL fragment)            |          |
 
 **Important note :** this output may evolve quite soon!
 
@@ -419,7 +426,8 @@ $ curl -H "Content-Type: application/json" \
           "type": "project",
           "id": 42,
           "attributes": {
-            "name": "damn-good-coffee"
+            "name": "damn-good-coffee",
+            "slug": "damn-good-coffee"
           }
         }
       }

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -3,6 +3,10 @@ FactoryGirl.define do
     sequence(:name, 'a') { |n| "my-project-#{ n }" }
     user
 
+    after(:build) do |project|
+      project.slug = project.name
+    end
+
     trait :newed do
       state 'newed'
       started_at nil

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,11 +1,7 @@
 FactoryGirl.define do
   factory :project, traits: [:newed] do
-    sequence(:name, 'a') { |n| "my-project-#{ n }" }
+    sequence(:name, 'a') { |n| "My project #{n}" }
     user
-
-    after(:build) do |project|
-      project.slug = project.name
-    end
 
     trait :newed do
       state 'newed'

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -135,26 +135,6 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  describe '#name' do
-    it 'does not accept names with spaces inside' do
-      project = build :project, name: 'invalid name'
-      expect(project).to be_invalid
-    end
-
-    it 'accepts different names' do
-      project = build :project
-      names = [
-        'name', 'a-name', 'a_name', '-name-', '_name_', '1name42', '---', '42',
-        '_____', 'THE-NAME',
-      ]
-
-      names.each do |name|
-        project.name = name
-        expect(project).to be_valid, "#{ name } should be a valid name for a project"
-      end
-    end
-  end
-
   describe '#update_with_transition!' do
     subject { project.update_with_transition! params }
 

--- a/spec/requests/api/projects_request_spec.rb
+++ b/spec/requests/api/projects_request_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Api::ProjectsController, type: :request do
 
   describe 'PATCH #update' do
     let(:project) { create :project, :started, user: user,
-                                               name: 'my-project',
+                                               name: 'My project',
                                                description: 'Old description' }
     let(:payload) { {
       project: {
-        name: 'new-name-for-a-project',
+        name: 'New name for a project',
         description: 'New description',
         due_at: DateTime.new(2018, 1, 20).to_i,
       },
@@ -43,7 +43,7 @@ RSpec.describe Api::ProjectsController, type: :request do
 
       it 'saves the new project' do
         project.reload
-        expect(project.name).to eq('new-name-for-a-project')
+        expect(project.name).to eq('New name for a project')
         expect(project.slug).to eq('new-name-for-a-project')
         expect(project.description).to eq('New description')
         expect(project.due_at).to eq(DateTime.new(2018, 1, 20))
@@ -52,33 +52,11 @@ RSpec.describe Api::ProjectsController, type: :request do
       it 'returns the new project' do
         api_project = JSON.parse(response.body)['data']
         expect(api_project['id']).to eq(project.id)
-        expect(api_project['attributes']['name']).to eq('new-name-for-a-project')
+        expect(api_project['attributes']['name']).to eq('New name for a project')
         expect(api_project['attributes']['slug']).to eq('new-name-for-a-project')
         expect(api_project['attributes']['description']).to eq('New description')
         expect(api_project['attributes']['dueAt']).to eq(DateTime.new(2018, 1, 20).to_i)
       end
-    end
-
-    context 'with invalid name' do
-      let(:payload) { {
-        project: {
-          name: 'an invalid name',
-          description: 'New description',
-          due_at: DateTime.new(2018, 1, 20).to_i,
-        },
-      } }
-
-      before { subject }
-
-      it_behaves_like 'API errors', :unprocessable_entity, {
-        errors: [{
-          status: '422 Unprocessable Entity',
-          code: 'invalid',
-          title: 'Resource validation failed',
-          detail: 'Resource cannot be saved because of validation constraints.',
-          source: { pointer: '/project/name' },
-        }],
-      }
     end
 
     context 'with newed project' do

--- a/spec/requests/api/projects_request_spec.rb
+++ b/spec/requests/api/projects_request_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Api::ProjectsController, type: :request do
       it 'saves the new project' do
         project.reload
         expect(project.name).to eq('new-name-for-a-project')
+        expect(project.slug).to eq('new-name-for-a-project')
         expect(project.description).to eq('New description')
         expect(project.due_at).to eq(DateTime.new(2018, 1, 20))
       end
@@ -52,6 +53,7 @@ RSpec.describe Api::ProjectsController, type: :request do
         api_project = JSON.parse(response.body)['data']
         expect(api_project['id']).to eq(project.id)
         expect(api_project['attributes']['name']).to eq('new-name-for-a-project')
+        expect(api_project['attributes']['slug']).to eq('new-name-for-a-project')
         expect(api_project['attributes']['description']).to eq('New description')
         expect(api_project['attributes']['dueAt']).to eq(DateTime.new(2018, 1, 20).to_i)
       end

--- a/spec/requests/api/users/projects_request_spec.rb
+++ b/spec/requests/api/users/projects_request_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Api::Users::ProjectsController, type: :request do
     let(:token) { user.token }
     let(:payload) { {
       project: {
-        name: 'my-project',
+        name: 'My project',
       },
     } }
 
@@ -106,13 +106,14 @@ RSpec.describe Api::Users::ProjectsController, type: :request do
       end
 
       it 'saves the new project' do
-        expect(Project.find_by(name: 'my-project')).to be_present
+        expect(Project.find_by(name: 'My project')).to be_present
       end
 
       it 'returns the new project' do
         project = JSON.parse(response.body)['data']
         expect(project['id']).not_to be_nil
-        expect(project['attributes']['name']).to eq('my-project')
+        expect(project['attributes']['name']).to eq('My project')
+        expect(project['attributes']['slug']).to eq('my-project')
         expect(project['attributes']['isInProgress']).to be false
       end
     end
@@ -133,30 +134,10 @@ RSpec.describe Api::Users::ProjectsController, type: :request do
       }
     end
 
-    context 'with invalid name' do
-      let(:payload) { {
-        project: {
-          name: 'An invalid name',
-        },
-      } }
-
-      before { subject }
-
-      it_behaves_like 'API errors', :unprocessable_entity, {
-        errors: [{
-          status: '422 Unprocessable Entity',
-          code: 'invalid',
-          title: 'Resource validation failed',
-          detail: 'Resource cannot be saved because of validation constraints.',
-          source: { pointer: '/project/name' },
-        }],
-      }
-    end
-
     context 'with too long name' do
       let(:payload) { {
         project: {
-          name: 'my-project-my-project-my-project-my-project-my-project-my-project-my-project-my-project-my-project-my-project',
+          name: 'my project my project my project my project my project my project my project my project my project my project',
         },
       } }
 
@@ -185,7 +166,7 @@ RSpec.describe Api::Users::ProjectsController, type: :request do
           code: 'taken',
           title: 'Resource validation failed',
           detail: 'Resource cannot be saved because of validation constraints.',
-          source: { pointer: '/project/name' },
+          source: { pointer: '/project/slug' },
         }],
       }
     end

--- a/spec/support/api/schemas/projects/project.json
+++ b/spec/support/api/schemas/projects/project.json
@@ -6,10 +6,11 @@
     "id": { "type": "integer" },
     "attributes": {
       "type": "object",
-      "required": ["name", "description", "startedAt", "dueAt", "pausedAt",
-                   "finishedAt", "isInProgress", "state"],
+      "required": ["name", "slug", "description", "startedAt", "dueAt",
+                   "pausedAt", "finishedAt", "isInProgress", "state"],
       "properties": {
         "name": { "type": "string" },
+        "slug": { "type": "string" },
         "description": { "type": "string" },
         "state": { "type": "string" },
         "startedAt": { "type": "integer" },

--- a/spec/support/api/schemas/tasks/task.json
+++ b/spec/support/api/schemas/tasks/task.json
@@ -58,9 +58,10 @@
                     "id": { "type": "integer" },
                     "attributes": {
                       "type": "object",
-                      "required": ["name"],
+                      "required": ["name", "slug"],
                       "properties": {
-                        "name": { "type": "string" }
+                        "name": { "type": "string" },
+                        "slug": { "type": "string" }
                       },
                       "additionalProperties": false
                     }


### PR DESCRIPTION
Closes #168 

Changes proposed in this pull request:

- Provide a `slug` attribute to Project
- Remove project name's constraints
- Infer slug from project name

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] [document API changes](https://github.com/marienfressinaud/lessy/tree/master/docs/api) (optional)
- [ ] [document migration notes](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [ ] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/pull_request.md).
