### PR TITLE
imp: Improve ordering of project list

### DIFF
--- a/client/src/components/Ly/LyList/LyListGroup.vue
+++ b/client/src/components/Ly/LyList/LyListGroup.vue
@@ -31,6 +31,7 @@
     }
   }
   .ly-list-group-header {
+    width: 2rem;
     padding: .5rem;
 
     color: $ly-color-grey-50;

--- a/client/src/store/modules/projects.js
+++ b/client/src/store/modules/projects.js
@@ -56,7 +56,7 @@ const getters = {
   },
 
   listNotStartedByFirstCharacter (state, getters) {
-    return groupByFirstCharacter(getters.listNotStarted, 'name')
+    return groupByFirstCharacter(getters.listNotStarted, 'slug')
   },
 
   listInProgress (state, getters) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Group projects per slug's first character
- Fix group header to `2rem`

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] [document API changes](https://github.com/marienfressinaud/lessy/tree/master/docs/api) (optional)
- [x] [document migration notes](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/pull_request.md).
