### PR TITLE
fix: Enable project name full edition

### DIFF
--- a/client/src/components/projects/ProjectEditForm.vue
+++ b/client/src/components/projects/ProjectEditForm.vue
@@ -7,7 +7,7 @@
         v-model="name"
         :label="$t('projects.editForm.nameLabel')"
         :error="getErrors('/project/name')"
-        pattern="[\w\-]{1,100}"
+        pattern=".{1,100}"
         :caption="$t('projects.editForm.nameCaption')"
         autocomplete="off"
         required

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -178,7 +178,7 @@ export default {
       descriptionCaption: 'Description supports Markdown',
       dueLabel: 'Due on',
       nameLabel: 'Name',
-      nameCaption: 'Only letters, numbers, underscores (_) and hiphens (-)',
+      nameCaption: 'Max 100 characters.',
       submit: 'Validate',
     },
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove project name constraints on edition

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] [document API changes](https://github.com/marienfressinaud/lessy/tree/master/docs/api) (optional)
- [x] [document migration notes](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/pull_request.md).
