### PR TITLE
add: #179 Enable transformation of task in project

### DIFF
--- a/client/src/components/Ly/LyPopover/LyPopover.vue
+++ b/client/src/components/Ly/LyPopover/LyPopover.vue
@@ -25,6 +25,8 @@
     .tooltip-inner {
       min-width: 10rem;
 
+      font-size: 1rem;
+
       background-color: $ly-color-grey-10;
       box-shadow: 0 0 1px $ly-color-grey-90,
                   0 0 3px $ly-color-grey-40,

--- a/client/src/components/Ly/LyPopover/LyPopoverSeparator.vue
+++ b/client/src/components/Ly/LyPopover/LyPopoverSeparator.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="ly-popover-separator"></div>
+</template>
+
+<style lang="scss">
+  .ly-popover-separator {
+    margin: .25rem -.5rem;
+
+    border-top: 1px solid $ly-color-grey-40;
+  }
+</style>

--- a/client/src/components/Ly/LyPopover/index.js
+++ b/client/src/components/Ly/LyPopover/index.js
@@ -1,8 +1,10 @@
 import LyPopover from './LyPopover'
 import LyPopoverItem from './LyPopoverItem'
+import LyPopoverSeparator from './LyPopoverSeparator'
 
 export {
   LyPopover,
   LyPopoverItem,
+  LyPopoverSeparator,
 }
 export default LyPopover

--- a/client/src/components/design/DesignComponentsPage.vue
+++ b/client/src/components/design/DesignComponentsPage.vue
@@ -404,7 +404,7 @@
         </ly-form>
       </ly-modal>
 
-      <h2>ly-popover and ly-popover-item</h2>
+      <h2>ly-popover, ly-popover-item and ly-popover-separator</h2>
       <p>Popovers can be used to hide additional actions.</p>
 
       <ly-popover>
@@ -415,6 +415,8 @@
         <template slot="menu">
           <ly-popover-item>Show</ly-popover-item>
           <ly-popover-item>Edit</ly-popover-item>
+          <ly-popover-separator></ly-popover-separator>
+          <ly-popover-item>More actions</ly-popover-item>
         </template>
       </ly-popover>
 

--- a/client/src/components/projects/ProjectCreateForm.vue
+++ b/client/src/components/projects/ProjectCreateForm.vue
@@ -18,7 +18,7 @@
       <ly-button type="primary" submit>
         {{ $t('projects.createForm.submit') }}
       </ly-button>
-      <ly-button v-if="onCancel" @click="onCancel">
+      <ly-button @click="$emit('cancel')">
         {{ $t('projects.createForm.cancel') }}
       </ly-button>
     </ly-form-group>
@@ -32,13 +32,13 @@
     mixins: [ErrorsHandler],
 
     props: {
-      'onSuccess': { type: Function },
-      'onCancel': { type: Function },
+      initialName: { type: String },
+      autofocus: { type: Boolean },
     },
 
     data () {
       return {
-        name: '',
+        name: this.initialName || '',
       }
     },
 
@@ -53,9 +53,7 @@
             this.name = ''
             this.cleanErrors()
             nameInput && nameInput.focus()
-            if (typeof this.onSuccess === 'function') {
-              this.onSuccess(projectId)
-            }
+            this.$emit('success', projectId)
           })
           .catch((failure) => {
             this.setFailureErrors(failure)
@@ -65,7 +63,9 @@
     },
 
     mounted () {
-      this.$refs.nameInput.focus()
+      if (this.autofocus) {
+        this.$refs.nameInput.focus()
+      }
     },
   }
 </script>

--- a/client/src/components/projects/ProjectLayout.vue
+++ b/client/src/components/projects/ProjectLayout.vue
@@ -6,15 +6,24 @@
   import { mapGetters } from 'vuex'
 
   export default {
+    props: {
+      projectSlug: { type: String, required: true },
+    },
+
     computed: {
       ...mapGetters({
         project: 'projects/current',
       }),
     },
 
+    watch: {
+      projectSlug: function (projectSlug) {
+        this.$store.commit('projects/setCurrent', projectSlug)
+      },
+    },
+
     mounted () {
-      const { projectSlug } = this.$route.params
-      this.$store.commit('projects/setCurrent', projectSlug)
+      this.$store.commit('projects/setCurrent', this.projectSlug)
     },
 
     destroyed () {

--- a/client/src/components/projects/ProjectsInboxPage.vue
+++ b/client/src/components/projects/ProjectsInboxPage.vue
@@ -11,7 +11,8 @@
       </ly-button>
       <project-create-form
         v-else
-        :onCancel="disableCreateForm"
+        @cancel="disableCreateForm"
+        autofocus
       ></project-create-form>
 
       <ly-list :placeholder="$t('projects.inboxPage.projectsPlaceholder')">

--- a/client/src/components/tasks/TaskAttachProjectModal.vue
+++ b/client/src/components/tasks/TaskAttachProjectModal.vue
@@ -1,0 +1,26 @@
+<template>
+  <ly-modal :title="$t('tasks.modals.attachProjectTitle')">
+    <p class="text-secondary">«&nbsp;{{ task.label }}&nbsp;»</p>
+
+    <task-attach-project-form
+      :task="task"
+      @success="$emit('close')"
+      @cancel="$emit('close')"
+      autofocus
+    ></task-attach-project-form>
+  </ly-modal>
+</template>
+
+<script>
+  import TaskAttachProjectForm from './TaskAttachProjectForm'
+
+  export default {
+    props: {
+      task: { type: Object, required: true },
+    },
+
+    components: {
+      TaskAttachProjectForm,
+    },
+  }
+</script>

--- a/client/src/components/tasks/TaskItem.vue
+++ b/client/src/components/tasks/TaskItem.vue
@@ -77,34 +77,25 @@
     </ly-popover>
 
     <div>
-      <ly-modal v-if="showAttachProjectModal" :title="$t('tasks.modals.attachProjectTitle')">
-        <p class="text-secondary">«&nbsp;{{ task.label }}&nbsp;»</p>
+      <task-attach-project-modal
+        v-if="showAttachProjectModal"
+        :task="task"
+        @close="showAttachProjectModal = false"
+      ></task-attach-project-modal>
 
-        <task-attach-project-form
-          :task="task"
-          @success="showAttachProjectModal = false"
-          @cancel="showAttachProjectModal = false"
-          autofocus
-        ></task-attach-project-form>
-      </ly-modal>
-
-      <ly-modal v-if="showTransformInProjectModal" :title="$t('tasks.modals.transformInProjectTitle')">
-        <project-create-form
-          :initialName="task.label"
-          @success="onTaskTransformSuccess"
-          @cancel="showTransformInProjectModal = false"
-          autofocus
-        ></project-create-form>
-      </ly-modal>
+      <task-transform-in-project-modal
+        v-if="showTransformInProjectModal"
+        :task="task"
+        @close="showTransformInProjectModal = false"
+      ></task-transform-in-project-modal>
     </div>
   </ly-list-item>
 </template>
 
 <script>
   import TaskEditForm from './TaskEditForm'
-  import TaskAttachProjectForm from './TaskAttachProjectForm'
-
-  import ProjectCreateForm from 'src/components/projects/ProjectCreateForm'
+  import TaskAttachProjectModal from './TaskAttachProjectModal'
+  import TaskTransformInProjectModal from './TaskTransformInProjectModal'
 
   export default {
     props: {
@@ -115,8 +106,8 @@
 
     components: {
       TaskEditForm,
-      TaskAttachProjectForm,
-      ProjectCreateForm,
+      TaskAttachProjectModal,
+      TaskTransformInProjectModal,
     },
 
     data () {
@@ -146,17 +137,6 @@
         const { task } = this
         if (window.confirm(this.$t('tasks.item.confirmAbandon'))) {
           this.$store.dispatch('tasks/abandon', { task })
-        }
-      },
-
-      onTaskTransformSuccess (projectId) {
-        const { task } = this
-        const project = this.$store.getters['projects/findById'](projectId)
-
-        this.showTransformInProjectModal = false
-        this.$store.dispatch('tasks/abandon', { task })
-        if (project) {
-          this.$router.push(project.urlShow)
         }
       },
     },

--- a/client/src/components/tasks/TaskItem.vue
+++ b/client/src/components/tasks/TaskItem.vue
@@ -70,6 +70,7 @@
       <template slot="menu">
         <ly-popover-item @click="() => { this.editMode = true }">{{ $t('tasks.item.edit') }}</ly-popover-item>
         <ly-popover-item @click="confirmAbandon">{{ $t('tasks.item.abandon') }}</ly-popover-item>
+        <ly-popover-separator></ly-popover-separator>
         <ly-popover-item @click="showAttachProjectModal = true">{{ $t('tasks.item.attachToProject') }}</ly-popover-item>
       </template>
     </ly-popover>

--- a/client/src/components/tasks/TaskItem.vue
+++ b/client/src/components/tasks/TaskItem.vue
@@ -72,11 +72,12 @@
         <ly-popover-item @click="confirmAbandon">{{ $t('tasks.item.abandon') }}</ly-popover-item>
         <ly-popover-separator></ly-popover-separator>
         <ly-popover-item @click="showAttachProjectModal = true">{{ $t('tasks.item.attachToProject') }}</ly-popover-item>
+        <ly-popover-item @click="showTransformInProjectModal = true">{{ $t('tasks.item.transformInProject') }}</ly-popover-item>
       </template>
     </ly-popover>
 
     <div>
-      <ly-modal v-if="showAttachProjectModal" :title="$t('tasks.modal.title')">
+      <ly-modal v-if="showAttachProjectModal" :title="$t('tasks.modals.attachProjectTitle')">
         <p class="text-secondary">«&nbsp;{{ task.label }}&nbsp;»</p>
 
         <task-attach-project-form
@@ -86,6 +87,15 @@
           autofocus
         ></task-attach-project-form>
       </ly-modal>
+
+      <ly-modal v-if="showTransformInProjectModal" :title="$t('tasks.modals.transformInProjectTitle')">
+        <project-create-form
+          :initialName="task.label"
+          @success="onTaskTransformSuccess"
+          @cancel="showTransformInProjectModal = false"
+          autofocus
+        ></project-create-form>
+      </ly-modal>
     </div>
   </ly-list-item>
 </template>
@@ -93,6 +103,8 @@
 <script>
   import TaskEditForm from './TaskEditForm'
   import TaskAttachProjectForm from './TaskAttachProjectForm'
+
+  import ProjectCreateForm from 'src/components/projects/ProjectCreateForm'
 
   export default {
     props: {
@@ -104,12 +116,14 @@
     components: {
       TaskEditForm,
       TaskAttachProjectForm,
+      ProjectCreateForm,
     },
 
     data () {
       return {
         editMode: false,
         showAttachProjectModal: false,
+        showTransformInProjectModal: false,
       }
     },
 
@@ -132,6 +146,17 @@
         const { task } = this
         if (window.confirm(this.$t('tasks.item.confirmAbandon'))) {
           this.$store.dispatch('tasks/abandon', { task })
+        }
+      },
+
+      onTaskTransformSuccess (projectId) {
+        const { task } = this
+        const project = this.$store.getters['projects/findById'](projectId)
+
+        this.showTransformInProjectModal = false
+        this.$store.dispatch('tasks/abandon', { task })
+        if (project) {
+          this.$router.push(project.urlShow)
         }
       },
     },

--- a/client/src/components/tasks/TaskTransformInProjectModal.vue
+++ b/client/src/components/tasks/TaskTransformInProjectModal.vue
@@ -1,0 +1,37 @@
+<template>
+  <ly-modal :title="$t('tasks.modals.transformInProjectTitle')">
+    <project-create-form
+      :initialName="task.label"
+      @success="onTaskTransformSuccess"
+      @cancel="$emit('close')"
+      autofocus
+    ></project-create-form>
+  </ly-modal>
+</template>
+
+<script>
+  import ProjectCreateForm from 'src/components/projects/ProjectCreateForm'
+
+  export default {
+    props: {
+      task: { type: Object, required: true },
+    },
+
+    components: {
+      ProjectCreateForm,
+    },
+
+    methods: {
+      onTaskTransformSuccess (projectId) {
+        const { task } = this
+        const project = this.$store.getters['projects/findById'](projectId)
+
+        this.$store.dispatch('tasks/abandon', { task })
+        if (project) {
+          this.$router.push(project.urlShow)
+        }
+        this.$emit('close')
+      },
+    },
+  }
+</script>

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -282,6 +282,7 @@ export default {
       plan: 'Plan for today',
       replan: 'Replan for today',
       restarted: 'You’ve restarted this task once | You’ve restarted this task {count} times, what about splitting or renaming it so it would be easier to achieve?',
+      transformInProject: 'Transform in project',
     },
 
     list: {
@@ -294,8 +295,9 @@ export default {
       title: 'Tasks',
     },
 
-    modal: {
-      title: 'Attach task to a project',
+    modals: {
+      attachProjectTitle: 'Attach task to a project',
+      transformInProjectTitle: 'Transform task in a project',
     },
 
     statisticsPage: {

--- a/client/src/locales/fr.js
+++ b/client/src/locales/fr.js
@@ -282,6 +282,7 @@ export default {
       plan: 'Planifier pour aujourd’hui',
       replan: 'Planifier à nouveau pour aujourd’hui',
       restarted: 'Vous avez relancé cette tâche une fois | Vous avez relancé cette tâche {count} fois, que pensez-vous de l’idée de la scinder en plusieurs parties ou de la renommer afin qu’elle soit plus facile à accomplir ?',
+      transformInProject: 'Transformer en projet',
     },
 
     list: {
@@ -294,8 +295,9 @@ export default {
       title: 'Tâches',
     },
 
-    modal: {
-      title: 'Attacher la tâche à un projet',
+    modals: {
+      attachProjectTitle: 'Attacher la tâche à un projet',
+      transformInProjectTitle: 'Transformer la tâche en projet',
     },
 
     statisticsPage: {

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -9,7 +9,7 @@ import { LyForm, LyFormGroup, LyFormInput, LyFormSelect, LyFormTextarea } from '
 import LyIcon from './components/Ly/LyIcon'
 import { LyList, LyListGroup, LyListItem, LyListItemAdapt } from './components/Ly/LyList'
 import LyModal from './components/Ly/LyModal'
-import { LyPopover, LyPopoverItem } from './components/Ly/LyPopover'
+import { LyPopover, LyPopoverItem, LyPopoverSeparator } from './components/Ly/LyPopover'
 import LySection from './components/Ly/LySection'
 import LyTextContainer from './components/Ly/LyTextContainer'
 
@@ -56,6 +56,7 @@ Vue.component('ly-list-item-adapt', LyListItemAdapt)
 Vue.component('ly-modal', LyModal)
 Vue.component('ly-popover', LyPopover)
 Vue.component('ly-popover-item', LyPopoverItem)
+Vue.component('ly-popover-separator', LyPopoverSeparator)
 Vue.component('ly-section', LySection)
 Vue.component('ly-text-container', LyTextContainer)
 

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -61,6 +61,7 @@ const routes = [
           { path: 'start', component: ProjectStartPage, name: 'project/start', meta: { title: 'Project' } },
           { path: 'finish', component: ProjectFinishPage, name: 'project/finish', meta: { title: 'Project' } },
         ],
+        props: true,
       },
     ],
     meta: { restrictForAuth: true },

--- a/client/src/styles/components/_vue_tooltip.scss
+++ b/client/src/styles/components/_vue_tooltip.scss
@@ -1,16 +1,17 @@
-$popper-background-color: rgba($ly-color-grey-90, .9);
-
 .tooltip {
   .tooltip-inner {
-    background-color: $popper-background-color;
-    box-sizing: border-box;
-    color: #fff;
-    min-width: 120px;
-    max-width: 310px;
-    padding: 6px 10px;
-    border-radius: 3px;
     z-index: 100;
-    box-shadow: 2px 2px 3px rgba($ly-color-grey-50, 0.9);
+
+    min-width: 5rem;
+    max-width: 15rem;
+    padding: .25rem .5rem;
+
+    color: #fff;
+    font-size: .9rem;
+
+    background-color: $ly-color-grey-90;
+    box-shadow: 1px 2px 3px $ly-color-grey-40;
+    border-radius: .25rem;
   }
 
   .tooltip-arrow {
@@ -27,7 +28,7 @@ $popper-background-color: rgba($ly-color-grey-90, .9);
 
     .tooltip-arrow {
       border-width: .25rem .25rem 0 .25rem;
-      border-color: $popper-background-color transparent transparent transparent;
+      border-color: $ly-color-grey-90 transparent transparent transparent;
       bottom: -.25rem;
       margin-top: 0;
       margin-bottom: 0;
@@ -39,7 +40,7 @@ $popper-background-color: rgba($ly-color-grey-90, .9);
 
     .tooltip-arrow {
       border-width: 0 .25rem .25rem .25rem;
-      border-color: transparent transparent $popper-background-color transparent;
+      border-color: transparent transparent $ly-color-grey-90 transparent;
       top: -.25rem;
       margin-top: 0;
       margin-bottom: 0;
@@ -51,7 +52,7 @@ $popper-background-color: rgba($ly-color-grey-90, .9);
 
     .tooltip-arrow {
       border-width: .25rem .25rem .25rem 0;
-      border-color: transparent $popper-background-color transparent transparent;
+      border-color: transparent $ly-color-grey-90 transparent transparent;
       left: -.25rem;
       margin-left: 0;
       margin-right: 0;
@@ -63,7 +64,7 @@ $popper-background-color: rgba($ly-color-grey-90, .9);
 
     .tooltip-arrow {
       border-width: .25rem 0 .25rem .25rem;
-      border-color: transparent transparent transparent $popper-background-color;
+      border-color: transparent transparent transparent $ly-color-grey-90;
       right: -.25rem;
       margin-left: 0;
       margin-right: 0;


### PR DESCRIPTION
Closes #179 

Changes proposed in this pull request:

- Fix tooltip CSS
- Provide a `ly-popover-separator` component
- Make transformation of task in project possible via a modal
- Extract modals from `task-item`

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/api) and [changelog](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/pull_request.md).
