### PR TITLE
imp: #234 Handle task abandon confirmation through modal

### DIFF
--- a/client/src/components/Ly/LyModal.vue
+++ b/client/src/components/Ly/LyModal.vue
@@ -19,6 +19,14 @@
     props: {
       title: { type: String },
     },
+
+    beforeCreate () {
+      document.body.classList.add('modal-opened')
+    },
+
+    destroyed () {
+      document.body.classList.remove('modal-opened')
+    },
   }
 </script>
 
@@ -31,15 +39,16 @@
     left: 0;
     z-index: 999;
 
+    overflow-x: hidden;
+    overflow-y: auto;
+
     background-color: rgba($ly-color-grey-90, .5);
     transition: opacity .2s ease-in-out;
   }
 
   .ly-modal-container {
     max-width: 30rem;
-    margin-top: 10rem;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 5rem auto;
 
     background-color: $ly-color-grey-10;
     border-radius: .25rem;

--- a/client/src/components/tasks/TaskConfirmAbandonModal.vue
+++ b/client/src/components/tasks/TaskConfirmAbandonModal.vue
@@ -1,0 +1,33 @@
+<template>
+  <ly-modal :title="$t('tasks.modals.confirmAbandonTitle')">
+    <p>
+      {{ $t('tasks.modals.confirmAbandon', { label: task.label }) }}
+    </p>
+
+    <ly-form-group type="actions">
+      <ly-button type="primary" @click="abandon">
+        {{ $t('tasks.modals.submitAbandon') }}
+      </ly-button>
+      <ly-button @click="$emit('close')">
+        {{ $t('tasks.modals.cancel') }}
+      </ly-button>
+    </ly-form-group>
+  </ly-modal>
+</template>
+
+<script>
+  export default {
+    props: {
+      task: { type: Object, required: true },
+    },
+
+    methods: {
+      abandon () {
+        const { task } = this
+        this.$store
+          .dispatch('tasks/abandon', { task })
+          .then(() => this.$emit('close'))
+      },
+    },
+  }
+</script>

--- a/client/src/components/tasks/TaskItem.vue
+++ b/client/src/components/tasks/TaskItem.vue
@@ -69,30 +69,30 @@
 
       <template slot="menu">
         <ly-popover-item @click="() => { this.editMode = true }">{{ $t('tasks.item.edit') }}</ly-popover-item>
-        <ly-popover-item @click="showConfirmAbandonModal = true">{{ $t('tasks.item.abandon') }}</ly-popover-item>
+        <ly-popover-item @click="activeModal = 'abandon'">{{ $t('tasks.item.abandon') }}</ly-popover-item>
         <ly-popover-separator></ly-popover-separator>
-        <ly-popover-item @click="showAttachProjectModal = true">{{ $t('tasks.item.attachToProject') }}</ly-popover-item>
-        <ly-popover-item @click="showTransformInProjectModal = true">{{ $t('tasks.item.transformInProject') }}</ly-popover-item>
+        <ly-popover-item @click="activeModal = 'attach'">{{ $t('tasks.item.attachToProject') }}</ly-popover-item>
+        <ly-popover-item @click="activeModal = 'transform'">{{ $t('tasks.item.transformInProject') }}</ly-popover-item>
       </template>
     </ly-popover>
 
     <div>
       <task-confirm-abandon-modal
-        v-if="showConfirmAbandonModal"
+        v-if="activeModal === 'abandon'"
         :task="task"
-        @close="showConfirmAbandonModal = false"
+        @close="activeModal = null"
       ></task-confirm-abandon-modal>
 
       <task-attach-project-modal
-        v-if="showAttachProjectModal"
+        v-if="activeModal === 'attach'"
         :task="task"
-        @close="showAttachProjectModal = false"
+        @close="activeModal = null"
       ></task-attach-project-modal>
 
       <task-transform-in-project-modal
-        v-if="showTransformInProjectModal"
+        v-if="activeModal === 'transform'"
         :task="task"
-        @close="showTransformInProjectModal = false"
+        @close="activeModal = null"
       ></task-transform-in-project-modal>
     </div>
   </ly-list-item>
@@ -106,9 +106,9 @@
 
   export default {
     props: {
-      'task': { type: Object, required: true },
-      'notoggle': { type: Boolean },
-      'hideProjectBadge': { type: Boolean },
+      task: { type: Object, required: true },
+      notoggle: { type: Boolean },
+      hideProjectBadge: { type: Boolean },
     },
 
     components: {
@@ -121,9 +121,7 @@
     data () {
       return {
         editMode: false,
-        showConfirmAbandonModal: false,
-        showAttachProjectModal: false,
-        showTransformInProjectModal: false,
+        activeModal: null,
       }
     },
 

--- a/client/src/components/tasks/TaskItem.vue
+++ b/client/src/components/tasks/TaskItem.vue
@@ -69,7 +69,7 @@
 
       <template slot="menu">
         <ly-popover-item @click="() => { this.editMode = true }">{{ $t('tasks.item.edit') }}</ly-popover-item>
-        <ly-popover-item @click="confirmAbandon">{{ $t('tasks.item.abandon') }}</ly-popover-item>
+        <ly-popover-item @click="showConfirmAbandonModal = true">{{ $t('tasks.item.abandon') }}</ly-popover-item>
         <ly-popover-separator></ly-popover-separator>
         <ly-popover-item @click="showAttachProjectModal = true">{{ $t('tasks.item.attachToProject') }}</ly-popover-item>
         <ly-popover-item @click="showTransformInProjectModal = true">{{ $t('tasks.item.transformInProject') }}</ly-popover-item>
@@ -77,6 +77,12 @@
     </ly-popover>
 
     <div>
+      <task-confirm-abandon-modal
+        v-if="showConfirmAbandonModal"
+        :task="task"
+        @close="showConfirmAbandonModal = false"
+      ></task-confirm-abandon-modal>
+
       <task-attach-project-modal
         v-if="showAttachProjectModal"
         :task="task"
@@ -94,6 +100,7 @@
 
 <script>
   import TaskEditForm from './TaskEditForm'
+  import TaskConfirmAbandonModal from './TaskConfirmAbandonModal'
   import TaskAttachProjectModal from './TaskAttachProjectModal'
   import TaskTransformInProjectModal from './TaskTransformInProjectModal'
 
@@ -106,6 +113,7 @@
 
     components: {
       TaskEditForm,
+      TaskConfirmAbandonModal,
       TaskAttachProjectModal,
       TaskTransformInProjectModal,
     },
@@ -113,6 +121,7 @@
     data () {
       return {
         editMode: false,
+        showConfirmAbandonModal: false,
         showAttachProjectModal: false,
         showTransformInProjectModal: false,
       }
@@ -131,13 +140,6 @@
       start () {
         const { task } = this
         this.$store.dispatch('tasks/start', { task })
-      },
-
-      confirmAbandon () {
-        const { task } = this
-        if (window.confirm(this.$t('tasks.item.confirmAbandon'))) {
-          this.$store.dispatch('tasks/abandon', { task })
-        }
       },
     },
   }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -273,7 +273,6 @@ export default {
     item: {
       abandon: 'Abandon',
       attachToProject: 'Attach to a project',
-      confirmAbandon: 'Oh? The task will be marked as abandoned and will disappear from the list. Can you confirm?',
       startedSinceWeeks: 'You’ve started this task 1 week ago | You’ve started this task {count} weeks ago, it may be time to abandon it, don’t you think?',
       dueOn: 'due on {date}',
       edit: 'Edit',
@@ -297,6 +296,10 @@ export default {
 
     modals: {
       attachProjectTitle: 'Attach task to a project',
+      cancel: 'Cancel',
+      confirmAbandon: 'The task « {label} » will be marked as abandoned and will disappear from the list. Can you confirm?',
+      confirmAbandonTitle: 'Abandon task',
+      submitAbandon: 'Confirm abandon',
       transformInProjectTitle: 'Transform task in a project',
     },
 

--- a/client/src/locales/fr.js
+++ b/client/src/locales/fr.js
@@ -273,7 +273,6 @@ export default {
     item: {
       abandon: 'Abandonner',
       attachToProject: 'Attacher à un projet',
-      confirmAbandon: 'Vraiment ? La tâche sera marquée comme abandonnée et disparaîtra de la liste. Vous confirmez ?',
       startedSinceWeeks: 'Vous avez créé cette tâche il y a une semaine | Vous avez créé cette tâche il y a {count} semaines, peut-être est-il temps de l’abandonner, qu’en pensez-vous ?',
       dueOn: 'date d’échéance {date}',
       edit: 'Modifier',
@@ -297,6 +296,10 @@ export default {
 
     modals: {
       attachProjectTitle: 'Attacher la tâche à un projet',
+      cancel: 'Annuler',
+      confirmAbandon: 'La tâche « {label} » sera marquée comme abandonnée et disparaîtra de la liste. Confirmez-vous ?',
+      confirmAbandonTitle: 'Abandonner la tâche',
+      submitAbandon: 'Confirmer l’abandon',
       transformInProjectTitle: 'Transformer la tâche en projet',
     },
 

--- a/client/src/styles/app.scss
+++ b/client/src/styles/app.scss
@@ -20,6 +20,10 @@ body {
   background-color: $ly-color-pine-60;
 }
 
+body.modal-opened {
+  overflow: hidden;
+}
+
 img {
   height: auto;
   max-width: 100%;


### PR DESCRIPTION
Closes #234 

Changes proposed in this pull request:

- Handle task abandon through a modal
- Refactor modal selection in task-item
- Improve modal rendering when opened

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/api) and [changelog](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/pull_request.md).
