### PR TITLE
fix: #243 Remove finished projects of future list

### DIFF
--- a/client/src/components/projects/ProjectsInboxPage.vue
+++ b/client/src/components/projects/ProjectsInboxPage.vue
@@ -17,7 +17,7 @@
 
       <ly-list :placeholder="$t('projects.inboxPage.projectsPlaceholder')">
         <ly-list-group
-          v-for="(projects, firstCharacter) in notStartedProjects"
+          v-for="(projects, firstCharacter) in futureProjects"
           :name="firstCharacter"
         >
           <project-item
@@ -62,7 +62,7 @@
 
     computed: {
       ...mapGetters({
-        notStartedProjects: 'projects/listNotStartedByFirstCharacter',
+        futureProjects: 'projects/listFutureByFirstCharacter',
         finishedProjects: 'projects/listFinished',
       }),
     },

--- a/client/src/components/tasks/TaskAttachProjectForm.vue
+++ b/client/src/components/tasks/TaskAttachProjectForm.vue
@@ -43,14 +43,14 @@
 
     computed: {
       ...mapGetters({
-        startedProjects: 'projects/listInProgress',
-        notStartedProjects: 'projects/listNotStarted',
+        inProgressProjects: 'projects/listInProgress',
+        futureProjects: 'projects/listFuture',
       }),
 
       options () {
         return [
-          ...objectsToOptions(this.startedProjects, 'id', 'name'),
-          ...objectsToOptions(this.notStartedProjects, 'id', 'name'),
+          ...objectsToOptions(this.inProgressProjects, 'id', 'name'),
+          ...objectsToOptions(this.futureProjects, 'id', 'name'),
         ]
       },
     },

--- a/client/src/store/modules/projects.js
+++ b/client/src/store/modules/projects.js
@@ -22,11 +22,13 @@ const getters = {
       const params = {
         projectSlug: project.slug,
       }
+      const isNewed = project.state === 'newed'
       const isStarted = project.state === 'started'
       const isPaused = project.state === 'paused'
       const isFinished = project.state === 'finished'
       return {
         ...project,
+        isNewed,
         isStarted,
         isPaused,
         isFinished,
@@ -48,15 +50,15 @@ const getters = {
                  .map(getters.findById)
   },
 
-  listNotStarted (state, getters) {
+  listFuture (state, getters) {
     return getters
       .list
-      .filter((project) => !project.isStarted)
+      .filter((project) => project.isPaused || project.isNewed)
       .sort((p1, p2) => p1.name.localeCompare(p2.name))
   },
 
-  listNotStartedByFirstCharacter (state, getters) {
-    return groupByFirstCharacter(getters.listNotStarted, 'slug')
+  listFutureByFirstCharacter (state, getters) {
+    return groupByFirstCharacter(getters.listFuture, 'slug')
   },
 
   listInProgress (state, getters) {


### PR DESCRIPTION
Closes #243 

Changes proposed in this pull request:

- Rename `notStarted` projects in `future` projects
- Adapt related condition so finished projects are not listed as future projects 

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/api) and [changelog](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/pull_request.md).
