### PR TITLE
tec: Remove test suite for Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
   - 2.4.2
-  - 2.3.4
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Migration notes
 
 - `Dockerfile.prod` is renamed in `Dockerfile`
+- Remove unofficial support of Ruby 2.3 (for test suite)
 
 ## Aquarius 2017-12-29
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove test suite for Ruby 2.3 (we only support Ruby 2.4 officialy)

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/api) and [changelog](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/marienfressinaud/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/marienfressinaud/lessy/tree/master/docs/pull_request.md).
